### PR TITLE
update for ucm version M4

### DIFF
--- a/ucm-bin/.SRCINFO
+++ b/ucm-bin/.SRCINFO
@@ -1,16 +1,15 @@
 pkgbase = ucm-bin
 	pkgdesc = Unison language code manager
-	pkgver = M2j
+	pkgver = M4
 	pkgrel = 1
-	url = https://www.unisonweb.org
+	url = https://www.unison-lang.org/
 	arch = x86_64
 	license = custom
-	depends = ncurses5-compat-libs
 	depends = gmp
 	depends = zlib
-	source = ucm-M2j::https://github.com/unisonweb/unison/releases/download/release/M2j/ucm-linux.tar.gz
-	source = https://raw.githubusercontent.com/unisonweb/unison/release/M2j/LICENSE
-	sha256sums = a950c6106c71c483fd3c890b081957d24662edda03cba8219391cb4973b07163
-	sha256sums = 6dd1702f5e06317fef9577559ff85dae2aba622b0bc66f18db88c66ffeb693a2
+	source = ucm-M4::https://github.com/unisonweb/unison/releases/download/release%2FM4/ucm-linux.tar.gz
+	source = https://raw.githubusercontent.com/unisonweb/unison/release/M4/LICENSE
+	sha256sums = 3aab4988a02c79fc367d58e1b6c6147bea8b3ea5c13c590751a321dba109049e
+	sha256sums = b509f7dd073911b831418b6f6f654d16c43abd0fac5c9f12402873ec08849fa4
 
 pkgname = ucm-bin

--- a/ucm-bin/PKGBUILD
+++ b/ucm-bin/PKGBUILD
@@ -1,17 +1,17 @@
 # Maintainer: Martynas Mickevičius <self at 2m dot lt>
 pkgname=ucm-bin
-pkgver=M2j
+pkgver=M4
 pkgrel=1
 pkgdesc='Unison language code manager'
 arch=('x86_64')
-url='https://www.unisonweb.org'
+url='https://www.unison-lang.org/'
 license=('custom')
-depends=('ncurses5-compat-libs' 'gmp' 'zlib')
+depends=('gmp' 'zlib')
 
-source=("ucm-$pkgver::https://github.com/unisonweb/unison/releases/download/release/$pkgver/ucm-linux.tar.gz"
+source=("ucm-$pkgver::https://github.com/unisonweb/unison/releases/download/release%2F$pkgver/ucm-linux.tar.gz"
         "https://raw.githubusercontent.com/unisonweb/unison/release/$pkgver/LICENSE")
-sha256sums=('a950c6106c71c483fd3c890b081957d24662edda03cba8219391cb4973b07163'
-            '6dd1702f5e06317fef9577559ff85dae2aba622b0bc66f18db88c66ffeb693a2')
+sha256sums=('3aab4988a02c79fc367d58e1b6c6147bea8b3ea5c13c590751a321dba109049e'
+            'b509f7dd073911b831418b6f6f654d16c43abd0fac5c9f12402873ec08849fa4')
 
 package() {
   install -D -m755 ucm "$pkgdir/usr/bin/ucm"


### PR DESCRIPTION
Hi,

This PR should update your pkgbuild to install the M4 release of ucm. Note that I removed the 'ncurses5-compat-libs' dependency, since ucm seems to run fine without it. However, I'm not sure whether perhaps this package should depend on 'ncurses' or anything else.

Hope this helps.

Cheers!

Jovis