### PR TITLE
Update for ucm version M4i

### DIFF
--- a/ucm-bin/.SRCINFO
+++ b/ucm-bin/.SRCINFO
@@ -1,15 +1,15 @@
 pkgbase = ucm-bin
 	pkgdesc = Unison language code manager
-	pkgver = M4
+	pkgver = M4i
 	pkgrel = 1
 	url = https://www.unison-lang.org/
 	arch = x86_64
 	license = custom
 	depends = gmp
 	depends = zlib
-	source = ucm-M4::https://github.com/unisonweb/unison/releases/download/release%2FM4/ucm-linux.tar.gz
-	source = https://raw.githubusercontent.com/unisonweb/unison/release/M4/LICENSE
-	sha256sums = 3aab4988a02c79fc367d58e1b6c6147bea8b3ea5c13c590751a321dba109049e
-	sha256sums = b509f7dd073911b831418b6f6f654d16c43abd0fac5c9f12402873ec08849fa4
+	source = ucm-M4i::https://github.com/unisonweb/unison/releases/download/release%2FM4i/ucm-linux.tar.gz
+	source = https://raw.githubusercontent.com/unisonweb/unison/release/M4i/LICENSE
+	sha256sums = 431f2f3bf55acf455d0865f023045022e325a78e21c42ae843b9bb63e9bb6979
+	sha256sums = 83b0f93a80eeb42f9894851822623bdd5c88cc63fa127d09f0a76d9799913d08
 
 pkgname = ucm-bin

--- a/ucm-bin/PKGBUILD
+++ b/ucm-bin/PKGBUILD
@@ -14,6 +14,15 @@ sha256sums=('431f2f3bf55acf455d0865f023045022e325a78e21c42ae843b9bb63e9bb6979'
             '83b0f93a80eeb42f9894851822623bdd5c88cc63fa127d09f0a76d9799913d08')
 
 package() {
-  install -D -m755 ucm "$pkgdir/usr/bin/ucm"
+  install -D -m755 ucm "$pkgdir/usr/share/ucm/ucm"
+  cp -rv "$srcdir/ui" "$pkgdir/usr/share/ucm/ui"
   install -Dm644 LICENSE "$pkgdir/usr/share/licenses/$pkgname/LICENSE"
+
+  mkdir -p "${pkgdir}/usr/bin"
+  cat > "${pkgdir}/usr/bin/ucm" <<-EOF
+	#!/bin/sh
+	export UCM_WEB_UI="\${UCM_WEB_UI-/usr/share/ucm/ui}"
+	exec /usr/share/ucm/ucm
+	EOF
+  chmod +x "${pkgdir}/usr/bin/ucm"
 }

--- a/ucm-bin/PKGBUILD
+++ b/ucm-bin/PKGBUILD
@@ -1,6 +1,6 @@
 # Maintainer: Martynas Mickevičius <self at 2m dot lt>
 pkgname=ucm-bin
-pkgver=M4
+pkgver=M4i
 pkgrel=1
 pkgdesc='Unison language code manager'
 arch=('x86_64')
@@ -10,8 +10,8 @@ depends=('gmp' 'zlib')
 
 source=("ucm-$pkgver::https://github.com/unisonweb/unison/releases/download/release%2F$pkgver/ucm-linux.tar.gz"
         "https://raw.githubusercontent.com/unisonweb/unison/release/$pkgver/LICENSE")
-sha256sums=('3aab4988a02c79fc367d58e1b6c6147bea8b3ea5c13c590751a321dba109049e'
-            'b509f7dd073911b831418b6f6f654d16c43abd0fac5c9f12402873ec08849fa4')
+sha256sums=('431f2f3bf55acf455d0865f023045022e325a78e21c42ae843b9bb63e9bb6979'
+            '83b0f93a80eeb42f9894851822623bdd5c88cc63fa127d09f0a76d9799913d08')
 
 package() {
   install -D -m755 ucm "$pkgdir/usr/bin/ucm"


### PR DESCRIPTION
Hello, and thanks for maintaining this package!

I'm just getting started with Unison, and I noticed that there's a newer release than the one this package installs.

I also found a UI bundle directory that's required for running the `ui` command in the UCM shell. Without the directory installed, I get this message when I try it:

> No codebase UI configured. Set the UCM_WEB_UI environment variable to the directory where the UI is installed.

This PR updates the PKGBUILD to install the latest release ([M4i]), including the `ui` directory. To set the correct default value for the `UCM_WEB_UI` variable, this now installs a wrapper script as `/usr/bin/ucm` and puts the packaged assets under `/usr/share/ucm`.

[M4i]: https://github.com/unisonweb/unison/releases/tag/release%2FM4i
